### PR TITLE
Allow multiple ignored tokens in a row

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,16 +13,16 @@ function makeLexer(tokens) {
   }
   
   lexer.next = function () {
-      try {
-          let token = oldnext.call(this);
-          if (token && this.ignore.has(token.type)) {
-              token = oldnext.call(this);
-          }
+    try {
+      while (true) {
+        let token = oldnext.call(this);
+        if (token == undefined || !this.ignore.has(token.type)) {
           return token;
-      } catch (e) {
-          console.error("Eh!\n" + e)
+        }
       }
-  
+    } catch (e) {
+        console.error("Eh!\n" + e)
+    }
   };
   return lexer;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const ins = obj => console.log(util.inspect(obj, { depth: null }));
 
 let s = `
 fun (id, idtwo, idthree)  
-  do  
+  do   #hello
     do end;
     do end
   end 


### PR DESCRIPTION
This change allows ignoring tokens even if several come in a row. Right now it is only ignoring one token. This can be seen for example when changing the test to have a comment, because then it ignores the first token (a whitespace), but still passes the comment to nearley even if it is an ignored token
```
Error: Syntax error at line 3 col 8:

    do   #hello
         ^
Unexpected ws token: "#hello". Instead, I was expecting to see one of the following:

A dolua token based on:
    DO →  ● %dolua
    Statement →  ● DO StList END
    StList →  ● Statement
    Statement → DO ● StList END
    StList →  ● Statement
    Function → FUN LP NameList RP ● StList END
    S →  ● Function
A ";" based on:
    SEMICOLON →  ● ";"
    StList → StList ● SEMICOLON Statement
    Statement → DO ● StList END
    StList →  ● Statement
    Function → FUN LP NameList RP ● StList END
    S →  ● Function
A end token based on:
    END →  ● %end
    Statement → DO StList ● END
    StList →  ● Statement
    Function → FUN LP NameList RP ● StList END
    S →  ● Function

    at Parser.feed (/home/usuario/PL/infix2evm-Daniel-del-Castillo/node_modules/nearley/lib/nearley.js:343:27)
    at Object.<anonymous> (/home/usuario/PL/infix2evm-Daniel-del-Castillo/moo-ignore/test/test.js:17:12)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:973:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
    at node:internal/main/run_main_module:17:47 {
  offset: 9,
  token: {
    type: 'ws',
    value: '#hello',
    text: '#hello',
    toString: [Function: tokenToString],
    offset: 35,
    lineBreaks: 0,
    line: 3,
    col: 8
  }
}
```